### PR TITLE
feat: exclude files pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ Parentheses are reserved in case this package adds support for Bash extended
 globbing in the future. For the time being, using them will throw an error
 unless they're escaped.
 
+### Exclude pattern: `!`
+
+For any files you wish to exclude, use the same glob pattern but prepend it with `!`
+
+```
+lint_staged:
+  'lib/**.dart': your-cmd
+  '!lib/**.g.dart': your-cmd
+```
+
+This would include all .dart files, but exclude .g.dart files.
+
+
 ## What commands are supported?
 
 Supported are any executables installed locally or globally via `pub` as well as any executable from your \$PATH.

--- a/lib/src/group.dart
+++ b/lib/src/group.dart
@@ -14,23 +14,32 @@ Map<String, Group> groupFilesByConfig(
     {required Map<String, List<String>> config, required List<String> files}) {
   final fileSet = files.toSet();
   final groups = <String, Group>{};
-  for (var entry in config.entries) {
-    final glob = Glob(entry.key);
-    final files = <String>[];
-    for (var file in fileSet) {
-      if (glob.matches(file)) {
-        files.add(file);
-      }
-    }
 
-    /// Files should only match a single entry
-    for (var file in files) {
-      fileSet.remove(file);
-    }
-    if (files.isNotEmpty) {
-      _verbose('$glob matched files: $files');
-      groups[entry.key] = Group(scripts: entry.value, files: files);
+  // Separate config into inclusion and exclusion patterns
+  final includeConfig = config.entries.where((e) => !e.key.startsWith('!'));
+  final excludeConfig = config.entries.where((e) => e.key.startsWith('!'));
+
+  // First, include files based on inclusion patterns
+  for (var entry in includeConfig) {
+    final glob = Glob(entry.key);
+    final matchedFiles = fileSet.where((file) => glob.matches(file)).toList();
+
+    if (matchedFiles.isNotEmpty) {
+      _verbose('$glob matched files: $matchedFiles');
+      groups[entry.key] = Group(scripts: entry.value, files: matchedFiles);
     }
   }
+
+  // Next, exclude files based on exclusion patterns
+  for (var entry in excludeConfig) {
+    final glob = Glob(entry.key.substring(1)); // Remove the '!' prefix
+    final excludedFiles = fileSet.where((file) => glob.matches(file)).toSet();
+
+    // Remove excluded files from each group
+    for (var group in groups.values) {
+      group.files.removeWhere((file) => excludedFiles.contains(file));
+    }
+  }
+
   return groups;
 }


### PR DESCRIPTION
@hyiso couldn't really figure out how to exclude files. Seems glob are inclusive, and in the code, it specifically removes files that are already matched (leaving it no chance to exclude files).

This uses a custom pattern where we can add a `!` before the pattern to exclude a pattern.