### PR TITLE
fix: memory leak due to un-limited process usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options:
                                      "--no-stash".
   --diff-filter [string]             override the default "--diff-filter=ACMR" flag of "git diff" to get list of files
   --no-stash                         disable the backup stash, and do not revert in case of errors
+  --processes [int]                  limit the maximum processes can run at the same time.
 ```
 
 - **`--allow-empty`**: By default, when linter tasks undo all staged changes, lint_staged will exit with an error and abort the commit. Use this flag to allow creating empty git commits.

--- a/bin/lint_staged.dart
+++ b/bin/lint_staged.dart
@@ -16,19 +16,27 @@ void main(List<String> arguments) async {
     ..addFlag('stash',
         defaultsTo: true,
         negatable: true,
-        help: 'Enable the backup stash, and revert in case of errors');
+        help: 'Enable the backup stash, and revert in case of errors')
+    ..addOption('processes',
+        defaultsTo: null,
+        abbr: 'p',
+        help:
+            'The maximum processes can run at the same time, limits it can reduce the memory usage');
   final argResults = argParser.parse(arguments);
   final allowEmpty = argResults['allow-empty'] == true;
   final diff = argResults['diff'];
   final diffFilter = argResults['diff-filter'];
   final stash = argResults['stash'] == true;
+  final numberOfProcessors = argResults['processes'] != null
+      ? int.parse(argResults['processes'])
+      : null;
   final passed = await lintStaged(
-    allowEmpty: allowEmpty,
-    diff: diff,
-    diffFilter: diffFilter,
-    stash: stash,
-    maxArgLength: _maxArgLength ~/ 2,
-  );
+      allowEmpty: allowEmpty,
+      diff: diff,
+      diffFilter: diffFilter,
+      stash: stash,
+      maxArgLength: _maxArgLength ~/ 2,
+      numOfProcesses: numberOfProcessors);
   exit(passed ? 0 : 1);
 }
 

--- a/lib/lint_staged.dart
+++ b/lib/lint_staged.dart
@@ -25,13 +25,14 @@ Future<bool> lintStaged({
 }) async {
   try {
     final ctx = await runAll(
-        allowEmpty: allowEmpty,
-        diff: diff,
-        diffFilter: diffFilter,
-        stash: stash,
-        maxArgLength: maxArgLength,
-        workingDirectory: workingDirectory,
-        numOfProcesses: numOfProcesses);
+      allowEmpty: allowEmpty,
+      diff: diff,
+      diffFilter: diffFilter,
+      stash: stash,
+      maxArgLength: maxArgLength,
+      workingDirectory: workingDirectory,
+      numOfProcesses: numOfProcesses,
+    );
     _printTaskOutput(ctx);
     return true;
   } catch (e) {

--- a/lib/lint_staged.dart
+++ b/lib/lint_staged.dart
@@ -21,6 +21,7 @@ Future<bool> lintStaged({
   bool stash = true,
   String? workingDirectory,
   int maxArgLength = 0,
+  int? numOfProcesses,
 }) async {
   try {
     final ctx = await runAll(
@@ -29,7 +30,8 @@ Future<bool> lintStaged({
         diffFilter: diffFilter,
         stash: stash,
         maxArgLength: maxArgLength,
-        workingDirectory: workingDirectory);
+        workingDirectory: workingDirectory,
+        numOfProcesses: numOfProcesses);
     _printTaskOutput(ctx);
     return true;
   } catch (e) {

--- a/lib/src/processes_pool.dart
+++ b/lib/src/processes_pool.dart
@@ -60,6 +60,8 @@ class ProcessesPool {
   final OnCompleted? onCompleted;
   bool isStarted = false;
 
+  int get tasksNumber => _tasks.length;
+
   ProcessesPool({
     this.size,
     this.onCompleted,
@@ -97,7 +99,7 @@ class ProcessesPool {
     }
     _processes.addAll(List.filled(size!, null));
     await Future.wait(List.generate(size!, (int index) async {
-      return runTaskSync(
+      return _runTaskSync(
         index: index,
         onCompleted: onCompleted ?? this.onCompleted,
       );
@@ -105,7 +107,7 @@ class ProcessesPool {
     isStarted = false;
   }
 
-  Future<ProcessResult?> runTaskSync({
+  Future<ProcessResult?> _runTaskSync({
     required int index,
     OnCompleted? onCompleted,
   }) async {
@@ -118,7 +120,7 @@ class ProcessesPool {
     _processes[index] = null;
     onCompleted?.call(result);
 
-    return runTaskSync(
+    return _runTaskSync(
       index: index,
       onCompleted: onCompleted,
     );

--- a/lib/src/processes_pool.dart
+++ b/lib/src/processes_pool.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+
+typedef OnCompleted = void Function(ProcessResult result);
+
+class ProcessTask {
+  final String executable;
+  final List<String> arguments;
+  final String? workingDirectory;
+  final Map<String, String>? environment;
+  final bool includeParentEnvironment;
+  final bool runInShell;
+  final Encoding? stdoutEncoding;
+  final Encoding? stderrEncoding;
+
+  /// The copy of the parameter of Process.run()
+  const ProcessTask(
+    this.executable,
+    this.arguments, {
+    this.workingDirectory,
+    this.environment,
+    this.includeParentEnvironment = true,
+    this.runInShell = false,
+    this.stdoutEncoding = systemEncoding,
+    this.stderrEncoding = systemEncoding,
+  });
+
+  Future<ProcessResult> run() async {
+    ProcessResult result = await Process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+    Process.killPid(result.pid);
+    return result;
+  }
+}
+
+class ProcessesPool {
+  final int? size;
+  final Queue<ProcessTask> _tasks = Queue();
+  final Map<ProcessTask, Future<ProcessResult>> _processes = {};
+  final OnCompleted? onCompleted;
+
+  ProcessesPool({
+    required this.size,
+    this.onCompleted,
+  });
+
+  Future<void> init({
+    List<ProcessTask> tasks = const [],
+    OnCompleted? onCompleted,
+  }) async {
+    _tasks.addAll(tasks);
+  }
+
+  Future<void> start({
+    OnCompleted? onCompleted,
+  }) async {
+    if (size == null) {
+      Future.wait(_tasks.map((task) async {
+        await task.run();
+        _tasks.remove(task);
+      }).toList());
+      return;
+    }
+    await Future.wait(List.generate(size!, (int index) {
+      return runTask(onCompleted: onCompleted ?? this.onCompleted);
+    }));
+  }
+
+  void addTask(ProcessTask task) {
+    _tasks.add(task);
+    if (size == null) {
+      runTask(onCompleted: onCompleted);
+    }
+  }
+
+  Future<ProcessResult> runTask({
+    OnCompleted? onCompleted,
+  }) {
+    ProcessTask task = _tasks.removeFirst();
+    Future<ProcessResult> process = task.run();
+    _processes[task] = process;
+    process.then((ProcessResult result) {
+      _processes.remove(task);
+      onCompleted?.call(result);
+      runTask(onCompleted: onCompleted);
+    });
+    return process;
+  }
+
+  void close() {
+    _tasks.clear();
+    _processes.clear(); // Process.run does not return process instance
+  }
+}

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -86,20 +86,15 @@ Future<Context> runAll({
   } else {
     spinner.skipped('Hide unstaged changes');
   }
-  spinner.progress('Run tasks for staged files...\n');
+  spinner.progress('Run tasks for staged files...');
   await Future.wait(groups.values.map((group) async {
     await Future.wait(group.scripts.map((script) async {
       final args = script.split(' ');
       final exe = args.removeAt(0);
       await Future.wait(group.files.map((file) async {
-        print('-------');
-        print(exe);
-        print(args);
-        print(file);
         final result = await Process.run(exe, [...args, file],
             workingDirectory: workingDirectory);
         final messsages = ['$script $file'];
-        print('==========> ${result.pid}, ${result.stdout}, ${result.stderr}');
         if (result.stderr.toString().trim().isNotEmpty) {
           messsages.add(red(result.stderr.toString().trim()));
         }

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -96,22 +96,25 @@ Future<Context> runAll({
       final exe = args.removeAt(0);
       for (var file in group.files) {
         processesPool.addTask(
-          ProcessTask(exe, [...args, file], workingDirectory: workingDirectory),
-          onCompleted: (result) {
-            final messsages = ['$script $file'];
-            if (result.stderr.toString().trim().isNotEmpty) {
-              messsages.add(red(result.stderr.toString().trim()));
-            }
-            if (result.stdout.toString().trim().isNotEmpty) {
-              messsages.add(result.stdout.toString().trim());
-            }
-            _verbose(messsages.join('\n'));
-            if (result.exitCode != 0) {
-              ctx.output.add(messsages.join('\n'));
-              ctx.errors.add(kTaskError);
-            }
-            Process.killPid(result.pid);
-          },
+          ProcessTask(
+            exe,
+            [...args, file],
+            workingDirectory: workingDirectory,
+            onCompleted: (result) {
+              final messsages = ['$script $file'];
+              if (result.stderr.toString().trim().isNotEmpty) {
+                messsages.add(red(result.stderr.toString().trim()));
+              }
+              if (result.stdout.toString().trim().isNotEmpty) {
+                messsages.add(result.stdout.toString().trim());
+              }
+              _verbose(messsages.join('\n'));
+              if (result.exitCode != 0) {
+                ctx.output.add(messsages.join('\n'));
+                ctx.errors.add(kTaskError);
+              }
+            },
+          ),
         );
       }
     }

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -8,6 +8,7 @@ import 'chunk.dart';
 import 'config.dart';
 import 'git.dart';
 import 'group.dart';
+import 'processes_pool.dart';
 import 'workflow.dart';
 import 'logging.dart';
 import 'message.dart';
@@ -23,6 +24,7 @@ Future<Context> runAll({
   bool stash = true,
   String? workingDirectory,
   int maxArgLength = 0,
+  int? numOfProcesses,
 }) async {
   final ctx = getInitialContext();
   final fs = FileSystem(workingDirectory);
@@ -87,29 +89,59 @@ Future<Context> runAll({
     spinner.skipped('Hide unstaged changes');
   }
   spinner.progress('Run tasks for staged files...');
-  await Future.wait(groups.values.map((group) async {
-    await Future.wait(group.scripts.map((script) async {
+  ProcessesPool processesPool = ProcessesPool(size: numOfProcesses);
+  for (var group in groups.values) {
+    for (var script in group.scripts) {
       final args = script.split(' ');
       final exe = args.removeAt(0);
-      await Future.wait(group.files.map((file) async {
-        final result = await Process.run(exe, [...args, file],
-            workingDirectory: workingDirectory);
-        final messsages = ['$script $file'];
-        if (result.stderr.toString().trim().isNotEmpty) {
-          messsages.add(red(result.stderr.toString().trim()));
-        }
-        if (result.stdout.toString().trim().isNotEmpty) {
-          messsages.add(result.stdout.toString().trim());
-        }
-        _verbose(messsages.join('\n'));
-        if (result.exitCode != 0) {
-          ctx.output.add(messsages.join('\n'));
-          ctx.errors.add(kTaskError);
-        }
-        Process.killPid(result.pid);
-      }));
-    }));
-  }));
+      for (var file in group.files) {
+        processesPool.addTask(
+          ProcessTask(exe, [...args, file], workingDirectory: workingDirectory),
+          onCompleted: (result) {
+            final messsages = ['$script $file'];
+            if (result.stderr.toString().trim().isNotEmpty) {
+              messsages.add(red(result.stderr.toString().trim()));
+            }
+            if (result.stdout.toString().trim().isNotEmpty) {
+              messsages.add(result.stdout.toString().trim());
+            }
+            _verbose(messsages.join('\n'));
+            if (result.exitCode != 0) {
+              ctx.output.add(messsages.join('\n'));
+              ctx.errors.add(kTaskError);
+            }
+            Process.killPid(result.pid);
+          },
+        );
+      }
+    }
+  }
+
+  await processesPool.start();
+  processesPool.close();
+  // await Future.wait(groups.values.map((group) async {
+  //   await Future.wait(group.scripts.map((script) async {
+  //     final args = script.split(' ');
+  //     final exe = args.removeAt(0);
+  //     await Future.wait(group.files.map((file) async {
+  //       final result = await Process.run(exe, [...args, file],
+  //           workingDirectory: workingDirectory);
+  //       final messsages = ['$script $file'];
+  //       if (result.stderr.toString().trim().isNotEmpty) {
+  //         messsages.add(red(result.stderr.toString().trim()));
+  //       }
+  //       if (result.stdout.toString().trim().isNotEmpty) {
+  //         messsages.add(result.stdout.toString().trim());
+  //       }
+  //       _verbose(messsages.join('\n'));
+  //       if (result.exitCode != 0) {
+  //         ctx.output.add(messsages.join('\n'));
+  //         ctx.errors.add(kTaskError);
+  //       }
+  //       Process.killPid(result.pid);
+  //     }));
+  //   }));
+  // }));
   spinner.success('Run tasks for staged files');
   if (!applyModifationsSkipped(ctx)) {
     spinner.progress('Apply modifications...');

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -86,15 +86,20 @@ Future<Context> runAll({
   } else {
     spinner.skipped('Hide unstaged changes');
   }
-  spinner.progress('Run tasks for staged files...');
+  spinner.progress('Run tasks for staged files...\n');
   await Future.wait(groups.values.map((group) async {
     await Future.wait(group.scripts.map((script) async {
       final args = script.split(' ');
       final exe = args.removeAt(0);
       await Future.wait(group.files.map((file) async {
+        print('-------');
+        print(exe);
+        print(args);
+        print(file);
         final result = await Process.run(exe, [...args, file],
             workingDirectory: workingDirectory);
         final messsages = ['$script $file'];
+        print('==========> ${result.pid}, ${result.stdout}, ${result.stderr}');
         if (result.stderr.toString().trim().isNotEmpty) {
           messsages.add(red(result.stderr.toString().trim()));
         }
@@ -106,6 +111,7 @@ Future<Context> runAll({
           ctx.output.add(messsages.join('\n'));
           ctx.errors.add(kTaskError);
         }
+        Process.killPid(result.pid);
       }));
     }));
   }));

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -122,29 +122,7 @@ Future<Context> runAll({
 
   await processesPool.start();
   processesPool.close();
-  // await Future.wait(groups.values.map((group) async {
-  //   await Future.wait(group.scripts.map((script) async {
-  //     final args = script.split(' ');
-  //     final exe = args.removeAt(0);
-  //     await Future.wait(group.files.map((file) async {
-  //       final result = await Process.run(exe, [...args, file],
-  //           workingDirectory: workingDirectory);
-  //       final messsages = ['$script $file'];
-  //       if (result.stderr.toString().trim().isNotEmpty) {
-  //         messsages.add(red(result.stderr.toString().trim()));
-  //       }
-  //       if (result.stdout.toString().trim().isNotEmpty) {
-  //         messsages.add(result.stdout.toString().trim());
-  //       }
-  //       _verbose(messsages.join('\n'));
-  //       if (result.exitCode != 0) {
-  //         ctx.output.add(messsages.join('\n'));
-  //         ctx.errors.add(kTaskError);
-  //       }
-  //       Process.killPid(result.pid);
-  //     }));
-  //   }));
-  // }));
+
   spinner.success('Run tasks for staged files');
   if (!applyModifationsSkipped(ctx)) {
     spinner.progress('Apply modifications...');

--- a/test/integration/basic_functionality_test_limited_processes.dart
+++ b/test/integration/basic_functionality_test_limited_processes.dart
@@ -1,0 +1,237 @@
+import 'package:test/test.dart';
+
+import '__fixtures__/config.dart';
+import '__fixtures__/file.dart';
+import 'utils.dart';
+
+void main() {
+  group('lint_staged', () {
+    test(
+        'commits entire staged file when no errors from linter when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.write('pubspec.yaml', kConfigFormatExit);
+
+      // Stage formatted file
+      await project.fs.write('lib/main.dart', kFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+
+      // Run lint_staged to automatically format the file and commit formatted file
+      await project.gitCommit();
+
+      // Nothing is wrong, so a new commit created
+      expect(await project.git.commitCount, equals(2));
+      expect(await project.git.lastCommit, contains('test'));
+      expect(await project.fs.read('lib/main.dart'), equals(kFormattedDart));
+    });
+
+    test(
+        'commits entire staged file when no errors and linter modifies file when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.write('pubspec.yaml', kConfigFormatFix);
+
+      // Stage multi unformatted files
+      await project.fs.write('lib/main.dart', kUnFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+
+      await project.fs.write('lib/foo.dart', kUnFormattedDart);
+      await project.git.run(['add', 'lib/foo.dart']);
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      await project.gitCommit();
+
+      // Nothing was wrong so the empty commit is created
+      expect(await project.git.commitCount, equals(2));
+      expect(await project.git.lastCommit, contains('test'));
+      expect(await project.fs.read('lib/main.dart'), equals(kFormattedDart));
+      expect(await project.fs.read('lib/foo.dart'), equals(kFormattedDart));
+    });
+
+    test(
+        'fails to commit entire staged file when errors from linter when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.write('pubspec.yaml', kConfigFormatExit);
+
+      // Stage unformatted file
+      await project.fs.write('lib/main.dart', kUnFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+      final status = await project.git.status();
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      await expectLater(project.gitCommit(), throwsIntegrationTestError);
+
+      // Nothing was wrong so the empty commit is created
+      expect(await project.git.commitCount, equals(1));
+      expect(await project.git.lastCommit, contains('initial commit'));
+      expect(await project.git.status(), equals(status));
+      expect(await project.fs.read('lib/main.dart'), equals(kUnFormattedDart));
+    });
+
+    test(
+        'fails to commit entire staged file when errors from linter and linter modifies files when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.write('pubspec.yaml', kConfigFormatFix);
+
+      // Stage invalid file
+      await project.fs.write('lib/main.dart', kInvalidDart);
+      await project.git.run(['add', 'lib/main.dart']);
+      final status = await project.git.status();
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      await expectLater(project.gitCommit(), throwsIntegrationTestError);
+
+      // Nothing was wrong so the empty commit is created
+      expect(await project.git.commitCount, equals(1));
+      expect(await project.git.lastCommit, contains('initial commit'));
+      expect(await project.git.status(), equals(status));
+      expect(await project.fs.read('lib/main.dart'), equals(kInvalidDart));
+    });
+
+    test(
+        'clears unstaged changes when linter applies same changes when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.append('pubspec.yaml', kConfigFormatFix);
+
+      // Stage unformatted file
+      await project.fs.append(
+        'lib/main.dart',
+        kUnFormattedDart,
+      );
+      await project.git.run(['add', 'lib/main.dart']);
+
+      // Replace unformatted file with formatted but do not stage changes
+      await project.fs.remove('lib/main.dart');
+      await project.fs.append('lib/main.dart', kFormattedDart);
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      await project.gitCommit();
+
+      // Nothing was wrong so the empty commit is created
+      expect(await project.git.commitCount, equals(2));
+      expect(await project.git.lastCommit, contains('test'));
+
+      // Latest commit contains pretty file
+      // `git show` strips empty line from here here
+      expect(await project.git.show(['HEAD:lib/main.dart']),
+          equals(kFormattedDart.trim()));
+
+      // Nothing is staged
+      expect(await project.git.status(), contains('nothing added to commit'));
+
+      // File is pretty, and has been edited
+      expect(await project.fs.read('lib/main.dart'), equals(kFormattedDart));
+    });
+
+    test('runs chunked tasks when necessary when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.write('pubspec.yaml', kConfigFormatExit);
+
+      // Stage two files
+      await project.fs.write('lib/main.dart', kFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+      await project.fs.write('lib/foo.dart', kFormattedDart);
+      await project.git.run(['add', 'lib/foo.dart']);
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      // Set maxArgLength low enough so that chunking is used
+      await project.gitCommit(maxArgLength: 10);
+
+      // Nothing was wrong so the empty commit is created
+      expect(await project.git.commitCount, equals(2));
+      expect(await project.git.lastCommit, contains('test'));
+      expect(await project.fs.read('lib/main.dart'), equals(kFormattedDart));
+      expect(await project.fs.read('lib/foo.dart'), equals(kFormattedDart));
+    });
+
+    test('fails when backup stash is missing when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+      final config = '''lint_staged:
+  'lib/**.dart': git stash drop
+''';
+      await project.fs.write('pubspec.yaml', config);
+
+      // Stage two files
+      await project.fs.write('lib/main.dart', kFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      // Set maxArgLength low enough so that chunking is used
+      expect(project.gitCommit(maxArgLength: 10), throwsIntegrationTestError);
+    });
+
+    test(
+        'works when a branch named stash exists when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+      await project.fs.write('pubspec.yaml', kConfigFormatExit);
+
+      // create a new branch called stash
+      await project.git.run(['branch', 'stash']);
+
+      // Stage two files
+      await project.fs.write('lib/main.dart', kFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+
+      // Run lint_staged to automatically format the file and commit formatted file
+      await project.gitCommit();
+
+      // Nothing is wrong, so a new commit is created and file is pretty
+      expect(await project.git.commitCount, equals(2));
+      expect(await project.git.lastCommit, contains('test'));
+      expect(await project.fs.read('lib/main.dart'), equals(kFormattedDart));
+    });
+
+    test('ignores files given in pubspec.yaml when size parameter is provided',
+        () async {
+      final project = IntegrationProject();
+      print('dir: ${project.path}');
+      await project.setup();
+
+      await project.fs.write('pubspec.yaml', kConfigFormatFixWithIgnore);
+
+      // Stage multi unformatted files
+      await project.fs.write('lib/main.dart', kUnFormattedDart);
+      await project.git.run(['add', 'lib/main.dart']);
+
+      await project.fs.write('lib/foo.g.dart', kUnFormattedDart);
+      await project.git.run(['add', 'lib/foo.g.dart']);
+
+      // Run lint_staged to automatically format the file and commit formatted files
+      await project.gitCommit();
+
+      // main.dart should be formatted, while foo.g.dart should not
+      expect(await project.git.commitCount, equals(2));
+      expect(await project.git.lastCommit, contains('test'));
+      expect(await project.fs.read('lib/main.dart'), equals(kFormattedDart));
+      expect(await project.fs.read('lib/foo.g.dart'), equals(kUnFormattedDart));
+    });
+  });
+}

--- a/test/integration/basic_functionality_test_limited_processes.dart
+++ b/test/integration/basic_functionality_test_limited_processes.dart
@@ -71,7 +71,9 @@ void main() {
       final status = await project.git.status();
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await expectLater(project.gitCommit(numOfProcesses: Platform.numberOfProcessors), throwsIntegrationTestError);
+      await expectLater(
+          project.gitCommit(numOfProcesses: Platform.numberOfProcessors),
+          throwsIntegrationTestError);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(1));
@@ -95,7 +97,9 @@ void main() {
       final status = await project.git.status();
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await expectLater(project.gitCommit(numOfProcesses: Platform.numberOfProcessors), throwsIntegrationTestError);
+      await expectLater(
+          project.gitCommit(numOfProcesses: Platform.numberOfProcessors),
+          throwsIntegrationTestError);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(1));
@@ -159,7 +163,10 @@ void main() {
 
       // Run lint_staged to automatically format the file and commit formatted files
       // Set maxArgLength low enough so that chunking is used
-      await project.gitCommit(numOfProcesses: Platform.numberOfProcessorsmaxArgLength: 10);
+      await project.gitCommit(
+        numOfProcesses: Platform.numberOfProcessors,
+        maxArgLength: 10,
+      );
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(2));
@@ -184,7 +191,12 @@ void main() {
 
       // Run lint_staged to automatically format the file and commit formatted files
       // Set maxArgLength low enough so that chunking is used
-      expect(project.gitCommit(numOfProcesses: Platform.numberOfProcessorsmaxArgLength: 10), throwsIntegrationTestError);
+      expect(
+          project.gitCommit(
+            numOfProcesses: Platform.numberOfProcessors,
+            maxArgLength: 10,
+          ),
+          throwsIntegrationTestError);
     });
 
     test(

--- a/test/integration/basic_functionality_test_limited_processes.dart
+++ b/test/integration/basic_functionality_test_limited_processes.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import '__fixtures__/config.dart';
@@ -20,7 +22,7 @@ void main() {
       await project.git.run(['add', 'lib/main.dart']);
 
       // Run lint_staged to automatically format the file and commit formatted file
-      await project.gitCommit();
+      await project.gitCommit(numOfProcesses: Platform.numberOfProcessors);
 
       // Nothing is wrong, so a new commit created
       expect(await project.git.commitCount, equals(2));
@@ -45,7 +47,7 @@ void main() {
       await project.git.run(['add', 'lib/foo.dart']);
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await project.gitCommit();
+      await project.gitCommit(numOfProcesses: Platform.numberOfProcessors);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(2));
@@ -69,7 +71,7 @@ void main() {
       final status = await project.git.status();
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await expectLater(project.gitCommit(), throwsIntegrationTestError);
+      await expectLater(project.gitCommit(numOfProcesses: Platform.numberOfProcessors), throwsIntegrationTestError);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(1));
@@ -93,7 +95,7 @@ void main() {
       final status = await project.git.status();
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await expectLater(project.gitCommit(), throwsIntegrationTestError);
+      await expectLater(project.gitCommit(numOfProcesses: Platform.numberOfProcessors), throwsIntegrationTestError);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(1));
@@ -123,7 +125,7 @@ void main() {
       await project.fs.append('lib/main.dart', kFormattedDart);
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await project.gitCommit();
+      await project.gitCommit(numOfProcesses: Platform.numberOfProcessors);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(2));
@@ -157,7 +159,7 @@ void main() {
 
       // Run lint_staged to automatically format the file and commit formatted files
       // Set maxArgLength low enough so that chunking is used
-      await project.gitCommit(maxArgLength: 10);
+      await project.gitCommit(numOfProcesses: Platform.numberOfProcessorsmaxArgLength: 10);
 
       // Nothing was wrong so the empty commit is created
       expect(await project.git.commitCount, equals(2));
@@ -182,7 +184,7 @@ void main() {
 
       // Run lint_staged to automatically format the file and commit formatted files
       // Set maxArgLength low enough so that chunking is used
-      expect(project.gitCommit(maxArgLength: 10), throwsIntegrationTestError);
+      expect(project.gitCommit(numOfProcesses: Platform.numberOfProcessorsmaxArgLength: 10), throwsIntegrationTestError);
     });
 
     test(
@@ -201,7 +203,7 @@ void main() {
       await project.git.run(['add', 'lib/main.dart']);
 
       // Run lint_staged to automatically format the file and commit formatted file
-      await project.gitCommit();
+      await project.gitCommit(numOfProcesses: Platform.numberOfProcessors);
 
       // Nothing is wrong, so a new commit is created and file is pretty
       expect(await project.git.commitCount, equals(2));
@@ -225,7 +227,7 @@ void main() {
       await project.git.run(['add', 'lib/foo.g.dart']);
 
       // Run lint_staged to automatically format the file and commit formatted files
-      await project.gitCommit();
+      await project.gitCommit(numOfProcesses: Platform.numberOfProcessors);
 
       // main.dart should be formatted, while foo.g.dart should not
       expect(await project.git.commitCount, equals(2));

--- a/test/integration/utils.dart
+++ b/test/integration/utils.dart
@@ -44,11 +44,14 @@ class IntegrationProject {
     bool allowEmpty = false,
     int maxArgLength = 0,
     List<String>? gitCommitArgs,
+    int? numOfProcesses,
   }) async {
     final passed = await lintStaged(
-        maxArgLength: maxArgLength,
-        allowEmpty: allowEmpty,
-        workingDirectory: path);
+      maxArgLength: maxArgLength,
+      allowEmpty: allowEmpty,
+      workingDirectory: path,
+      numOfProcesses: numOfProcesses,
+    );
     if (!passed) {
       throw IntegrationTestError();
     }

--- a/test/unit/processes_pool_test.dart
+++ b/test/unit/processes_pool_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:lint_staged/src/processes_pool.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CommandLineProcessesPool', () {
+    const size = 4;
+    const second = 2;
+    const command = 'sleep';
+    final task = ProcessTask(command, ['$second']);
+    test('should be able to pass size parameter', () {
+      ProcessesPool pool = ProcessesPool(size: size);
+      expect(pool.size, size);
+    });
+
+    test('should be able to add one task', () {
+      ProcessesPool pool = ProcessesPool(size: size);
+      pool.addTask(task);
+      expect(pool.tasksNumber, 1);
+    });
+    test('should be able to add multiple task', () {
+      final List<ProcessTask> tasks =
+          List.filled(Platform.numberOfProcessors, task);
+      ProcessesPool pool = ProcessesPool(size: size);
+      pool.addAll(tasks: tasks);
+      expect(pool.tasksNumber, tasks.length);
+    });
+    test('should be able to run all tasks at the same time when size is null',
+        () async {
+      final List<ProcessTask> tasks =
+          List.filled(Platform.numberOfProcessors, task);
+      ProcessesPool pool = ProcessesPool();
+      pool.addAll(tasks: tasks);
+      Stopwatch stopwatch = Stopwatch()..start();
+      await pool.start();
+      stopwatch.stop();
+      expect(stopwatch.elapsed.inSeconds, lessThan(second * 2));
+    });
+    test('should be able to limit running task if provided size', () async {
+      final List<ProcessTask> tasks =
+          List.filled(Platform.numberOfProcessors, task);
+      ProcessesPool pool = ProcessesPool(size: size);
+      pool.addAll(tasks: tasks);
+      Stopwatch stopwatch = Stopwatch()..start();
+      await pool.start();
+      stopwatch.stop();
+      expect(stopwatch.elapsed.inSeconds,
+          lessThan(Platform.numberOfProcessors ~/ 2 + 1));
+    });
+  });
+}


### PR DESCRIPTION
@hyiso Based on the [issue](https://github.com/hyiso/lint_staged/issues/15) of the high memory usage, and the suggestion @BTMuli provided. I added a new parameter to limit the maximum processes can run at the same time.

1. I have tested that using Process.kill helps reduce memory usage somewhat. As shown in the image below, macOS does not aggressively terminate processes on its own, so manual termination is necessary.

<img width="429" alt="Screenshot 2024-06-08 at 22 17 28" src="https://github.com/hyiso/lint_staged/assets/66697085/97471004-1b1a-4933-b2ad-c9fe44882e93">

2. I tested it on a random open-source project and successfully reduced memory usage.


The default behaviour is the same (Does not set the process parameter).
![Run all](https://github.com/hyiso/lint_staged/assets/66697085/9bafe311-3337-4d1c-9145-6fb0e58a8181)

If I added the `--process 8`.
![Limited](https://github.com/hyiso/lint_staged/assets/66697085/b236999a-3476-4ddb-9562-cbe809d5c907)

And this is the memory usage of these two commands
![D2AF51B8-34F1-4D90-966C-518C64543E6E_4_5005_c](https://github.com/hyiso/lint_staged/assets/66697085/b35518b5-adab-4322-9d20-f2855e7024d2)


3. I have covered it with both unit tests and integration tests.
4. I have updated the README.md


